### PR TITLE
feat:ログイン成功後にダッシュボード画面へ遷移する機能を実装

### DIFF
--- a/pomoapp-backend/app/main.py
+++ b/pomoapp-backend/app/main.py
@@ -12,7 +12,7 @@ frontend_origin = os.getenv("FRONTEND_ORIGIN", "http://localhost:5173")
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[frontend_origin],
+    allow_origins=["*"],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/pomoapp-frontend/package-lock.json
+++ b/pomoapp-frontend/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "clsx": "^2.1.1",
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "react-router-dom": "^7.6.3"
       },
       "devDependencies": {
         "@eslint/js": "^9.29.0",
@@ -2731,6 +2732,15 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -5555,6 +5565,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.3.tgz",
+      "integrity": "sha512-zf45LZp5skDC6I3jDLXQUu0u26jtuP4lEGbc7BbdyxenBN1vJSTA18czM2D+h5qyMBuMrD+9uB+mU37HIoKGRA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.6.3.tgz",
+      "integrity": "sha512-DiWJm9qdUAmiJrVWaeJdu4TKu13+iB/8IEi0EW/XgaHCjW/vWGrwzup0GVvaMteuZjKnh5bEvJP/K0MDnzawHw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.6.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -5816,6 +5864,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/pomoapp-frontend/package.json
+++ b/pomoapp-frontend/package.json
@@ -15,7 +15,8 @@
   "dependencies": {
     "clsx": "^2.1.1",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-router-dom": "^7.6.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",

--- a/pomoapp-frontend/src/App.tsx
+++ b/pomoapp-frontend/src/App.tsx
@@ -1,12 +1,16 @@
-import React from 'react';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import Login from './components/Login';
+import Dashboard from './components/Dashboard';
 
-function App() {
+const App = () => {
   return (
-    <div>
-      <Login />
-    </div>
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<Login />} />
+        <Route path="/dashboard" element={<Dashboard />} />
+      </Routes>
+    </BrowserRouter>
   );
-}
+};
 
 export default App;

--- a/pomoapp-frontend/src/components/Dashboard.css
+++ b/pomoapp-frontend/src/components/Dashboard.css
@@ -1,0 +1,30 @@
+body {
+  margin: 0;
+  background-color: #000000;
+  font-family: 'Courier New', monospace;
+  color: #39ff14;
+}
+
+.dashboard {
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background-color: #000000;
+}
+
+.title {
+  font-size: 48px;
+  color: #39ff14;
+  text-shadow:
+    0 0 10px #39ff14,
+    0 0 20px #39ff14;
+  margin-bottom: 20px;
+}
+
+.timer {
+  font-size: 32px;
+  color: #39ff14;
+  text-shadow: 0 0 5px #39ff14;
+}

--- a/pomoapp-frontend/src/components/Dashboard.tsx
+++ b/pomoapp-frontend/src/components/Dashboard.tsx
@@ -1,0 +1,22 @@
+import React, { useState, useEffect } from 'react';
+import './Dashboard.css'; // 外部CSSでスタイル適用
+
+const Dashboard = () => {
+  const [seconds, setSeconds] = useState(0);
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setSeconds((prev) => prev + 1);
+    }, 1000);
+    return () => clearInterval(timer);
+  }, []);
+
+  return (
+    <div className="dashboard">
+      <h1 className="title">DASHBOARD</h1>
+      <div className="timer">🕒 {seconds}s</div>
+    </div>
+  );
+};
+
+export default Dashboard;

--- a/pomoapp-frontend/src/components/Login.tsx
+++ b/pomoapp-frontend/src/components/Login.tsx
@@ -1,17 +1,22 @@
-import React, { useState } from 'react';
-import styles from './Login.module.css';
-import clsx from 'clsx';
+import React, { useState } from 'react'; // React本体と「状態管理用のフック」を読み込み
+import styles from './Login.module.css'; // CSSモジュール（別ファイル）をインポート
+import clsx from 'clsx'; // 条件付きでクラス名を合成するための便利ツール
+import { useNavigate } from 'react-router-dom';
 
 const Login = () => {
+  // useStateフックで状態を定義。フォームの入力値やエラー表示を管理する
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
-  const [showDanger, setShowDanger] = useState(false);
-  const [errorMessage, setErrorMessage] = useState('');
+  const [showDanger, setShowDanger] = useState(false); // エラー表示のON/OFF
+  const [errorMessage, setErrorMessage] = useState(''); // エラーメッセージの中身
+  const navigate = useNavigate();
 
+  // フォームが送信されたときに実行される処理
   const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
+    e.preventDefault(); // ページリロードを防ぐ（フォームのデフォ動作を止める）
 
     try {
+      // ログインAPIにPOSTリクエストを送信（入力データをJSON形式で送る）
       const res = await fetch('http://localhost:8000/api/login', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -19,17 +24,18 @@ const Login = () => {
       });
 
       if (res.ok) {
-        const data = await res.json();
         setShowDanger(false);
         setErrorMessage('');
-        alert(data.message); // "success" を表示
+        navigate('/dashboard');
       } else {
+        // 失敗：エラーメッセージを表示
         const data = await res.json();
         setShowDanger(true);
         setErrorMessage(data.detail || 'ログイン失敗');
       }
     } catch (err) {
-      console.error(err); // ログ出力（開発中に便利）
+      // ネットワークエラーなどで例外が発生したとき
+      console.error(err);
       setShowDanger(true);
       setErrorMessage('ネットワークエラー');
     }
@@ -37,12 +43,14 @@ const Login = () => {
 
   return (
     <div className={styles.container}>
+      {/* フォーム全体（エラー時に見た目を変えるために clsx を使って条件付きクラス付与） */}
       <form
         className={clsx(styles.form, showDanger && styles.errorMode)}
         onSubmit={handleSubmit}
       >
         <h2 className={styles.title}>LOGIN</h2>
 
+        {/* ユーザー名入力フィールド */}
         <div className={styles.inputWrapper}>
           <span className={styles.icon}>👤</span>
           <input
@@ -50,10 +58,11 @@ const Login = () => {
             placeholder="Username"
             className={styles.input}
             value={username}
-            onChange={(e) => setUsername(e.target.value)}
+            onChange={(e) => setUsername(e.target.value)} // 入力があるたびにstateを更新
           />
         </div>
 
+        {/* パスワード入力フィールド */}
         <div className={styles.inputWrapper}>
           <span className={styles.icon}>🔒</span>
           <input
@@ -61,12 +70,14 @@ const Login = () => {
             placeholder="Password"
             className={styles.input}
             value={password}
-            onChange={(e) => setPassword(e.target.value)}
+            onChange={(e) => setPassword(e.target.value)} // 同じくstate更新
           />
         </div>
 
+        {/* エラーメッセージ表示部分 */}
         {showDanger && <p className={styles.errorText}>{errorMessage}</p>}
 
+        {/* 送信ボタン */}
         <button type="submit" className={styles.button}>
           Enter
         </button>


### PR DESCRIPTION
closes #14

## 概要

ログイン成功時に `/dashboard` ページへ自動遷移する機能を実装しました。  
タイマーアプリのダッシュボード画面と連携するための初期ステップとなります。

---

## 実装内容

- `react-router-dom` を利用して画面遷移機能を導入
- `App.tsx` にルーティング設定を追加
  - `/` → ログイン画面
  - `/dashboard` → ダッシュボード画面
- `Login.tsx` に `useNavigate()` を使用し、ログイン成功時に `/dashboard` に遷移
- 仮の `Dashboard.tsx` コンポーネントを作成（黒背景＋ネオングリーンの簡易タイマー）

---

## 動作確認手順

1. ローカル環境でアプリを起動
2. 任意のユーザーでログイン
3. 成功レスポンスが返ると `/dashboard` にリダイレクトされ、タイマー画面が表示される

---

## 備考

- 今後、ダッシュボード画面に本機能のロジックを実装予定
- 認証状態の保持、リダイレクト制御は別Issueで対応予定
