### PR TITLE
feat:ReactフォームからFastAPIに単語をPOSTしてオウム返し応答を実装

### DIFF
--- a/pomoapp-backend/app/api/dashboard.py
+++ b/pomoapp-backend/app/api/dashboard.py
@@ -1,0 +1,14 @@
+# app/api/dashboard.py
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+router = APIRouter()
+
+class WordRequest(BaseModel):
+    word: str
+
+@router.post("/word")
+async def receive_word(request: WordRequest):
+    print(f"受信した単語: {request.word}")
+    return {"message": f"受け取りました: {request.word}"}

--- a/pomoapp-backend/app/api/routes.py
+++ b/pomoapp-backend/app/api/routes.py
@@ -1,8 +1,9 @@
+# app/api/routes.py
+
 from fastapi import APIRouter
+from . import dashboard
 
 router = APIRouter()
 
-
-@router.get("/")
-def root():
-    return {"message": "Hello from structured FastAPI!"}
+# 各モジュールのrouterを統合
+router.include_router(dashboard.router)

--- a/pomoapp-backend/app/main.py
+++ b/pomoapp-backend/app/main.py
@@ -4,6 +4,8 @@ from fastapi.middleware.cors import CORSMiddleware
 from dotenv import load_dotenv
 import os
 
+from app.api.routes import router as api_router  # ← 追加
+
 load_dotenv()
 
 app = FastAPI()
@@ -12,18 +14,18 @@ frontend_origin = os.getenv("FRONTEND_ORIGIN", "http://localhost:5173")
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=["*"],  # 必要であれば [frontend_origin] に変更
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
 )
 
-# 管理されるユーザー一覧（username: password）
+# 🔐 ログイン処理（暫定的にmain.pyに残すならここ）
 USERS = {
     "hisa": "hisa",
     "yama": "yama",
     "aka": "aka",
-    "test": "1234",  # 追加ユーザー
+    "test": "1234",
 }
 
 class LoginRequest(BaseModel):
@@ -35,3 +37,6 @@ def login(req: LoginRequest):
     if USERS.get(req.username) == req.password:
         return {"message": "success"}
     raise HTTPException(status_code=401, detail="ユーザー名またはパスワードが違います")
+
+# ✅ APIルーティングまとめて登録（wordなどを含む）
+app.include_router(api_router, prefix="/api")

--- a/pomoapp-frontend/src/pages/Dashboard.tsx
+++ b/pomoapp-frontend/src/pages/Dashboard.tsx
@@ -38,9 +38,24 @@ const Dashboard = () => {
     return () => clearInterval(timer);
   }, []);
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    console.log('送信された単語:', word);
+
+    try {
+      const response = await fetch('http://localhost:8000/api/word', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ word }),
+      });
+
+      const data = await response.json();
+      console.log('サーバーからの応答:', data.message);
+    } catch (err) {
+      console.error('送信エラー:', err);
+    }
+
     setWord('');
   };
 


### PR DESCRIPTION
closes #23

## 変更内容 
- フロントエンドのフォームから単語を入力して送信
- FastAPIサーバー側で `/api/word` エンドポイントを実装
- 受け取った単語をオウム返しでレスポンス
- CORS対応と状態管理も含む

<img width="367" height="55" alt="Image" src="https://github.com/user-attachments/assets/f443825c-2b00-4db0-94e7-4bec74f2ea31" />